### PR TITLE
feat: Date Time Pattern fix for 2dp date milliseconds

### DIFF
--- a/src/main/java/com/monnify/utils/DateUtils.java
+++ b/src/main/java/com/monnify/utils/DateUtils.java
@@ -2,7 +2,9 @@ package com.monnify.utils;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
 import java.util.List;
 import java.util.Locale;
 
@@ -17,7 +19,11 @@ public class DateUtils {
             DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.ENGLISH),
             DateTimeFormatter.ofPattern("dd/MM/yyyy h:mm:ss a", Locale.ENGLISH),
             DateTimeFormatter.ofPattern("dd/MM/yyyy hh:mm:ss a", Locale.ENGLISH),
-            DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss a", Locale.ENGLISH)
+            DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss a", Locale.ENGLISH),
+            new DateTimeFormatterBuilder()
+                    .appendPattern("yyyy-MM-dd HH:mm:ss")
+                    .appendFraction(ChronoField.MILLI_OF_SECOND, 1, 3, true) // Handles .1 to .999
+                    .toFormatter()
     );
 
     public static LocalDateTime parseFlexible(String dateStr) {


### PR DESCRIPTION
Fix date parsing issue for fractional seconds with less than 3 digits (e.g. .1, .12) by using a flexible formatter. 

Sample failed date "2025-08-01 14:30:45.12"