### PR TITLE
Add destination Account name to Single Disbursement and change name enquiry endpoint to use v2

### DIFF
--- a/src/main/java/com/monnify/models/disbursement/SingleDisbursementRequest.java
+++ b/src/main/java/com/monnify/models/disbursement/SingleDisbursementRequest.java
@@ -37,7 +37,7 @@ public class SingleDisbursementRequest {
     @NotBlank(message = "sourceAccountNumber is required")
     private String sourceAccountNumber;
 
-    @NotBlank(message = "sourceAccountNumber is required")
+    @NotBlank(message = "destinationAccountName is required")
     private String destinationAccountName;
 
     private Boolean async;

--- a/src/main/java/com/monnify/models/disbursement/SingleDisbursementRequest.java
+++ b/src/main/java/com/monnify/models/disbursement/SingleDisbursementRequest.java
@@ -37,5 +37,8 @@ public class SingleDisbursementRequest {
     @NotBlank(message = "sourceAccountNumber is required")
     private String sourceAccountNumber;
 
+    @NotBlank(message = "sourceAccountNumber is required")
+    private String destinationAccountName;
+
     private Boolean async;
 }

--- a/src/main/java/com/monnify/services/verification/VerificationService.java
+++ b/src/main/java/com/monnify/services/verification/VerificationService.java
@@ -46,7 +46,7 @@ public class VerificationService {
                 new TypeToken<MonnifyBaseResponse<BankValidationResponse>>() {};
 
         return monnifyClient.get(
-                "/api/v1/disbursements/account/validate",
+                "/api/v2/disbursements/account/validate",
                 null,
                 parameters,
                 typeToken

--- a/src/test/java/com/monnify/services/disbursement/DisbursementServiceTest.java
+++ b/src/test/java/com/monnify/services/disbursement/DisbursementServiceTest.java
@@ -39,6 +39,7 @@ class DisbursementServiceTest {
                 .currency("NGN")
                 .destinationBankCode("044")
                 .destinationAccountNumber("0104430292")
+                .destinationAccountName("Tester Test")
                 .reference(reference)
                 .narration("Test Single trnx" + randomNumber)
                 .build());


### PR DESCRIPTION
Added support for destination account name in the Single Disbursement API.
Updated the Name Enquiry endpoint to use the v2 API.